### PR TITLE
 Change to the column visibility attribute

### DIFF
--- a/demo/advanced-demo.html
+++ b/demo/advanced-demo.html
@@ -57,10 +57,10 @@
               <paper-menu class="dropdown-content">
                 <template is="dom-repeat" items="[[toggleColumns]]" as="column" index-as="index">
                   <paper-icon-item position="[[column.position]]" on-tap="_hideColumn">
-                    <template is="dom-if" if="[[column.show]]">
+                    <template is="dom-if" if="[[!column.hidden]]">
                       <iron-icon icon="visibility-off" item-icon></iron-icon>
                     </template>
-                    <template is="dom-if" if="[[!column.show]]">
+                    <template is="dom-if" if="[[column.hidden]]">
                       <iron-icon disabled icon="visibility" item-icon></iron-icon>
                     </template>
                     [[column.header]]
@@ -95,6 +95,11 @@
               <paper-datatable-api-column header="Color" property="color" filter>
                 <template>
                   <span>[[value]]</span>
+                </template>
+              </paper-datatable-api-column>
+              <paper-datatable-api-column header="Weight" property="weight" hideable hidden>
+                <template>
+                  <span>[[value.kg]]</span>
                 </template>
               </paper-datatable-api-column>
             </paper-datatable-api>

--- a/demo/advanced-pagination-front-side-demo.html
+++ b/demo/advanced-pagination-front-side-demo.html
@@ -48,10 +48,10 @@
               <paper-menu class="dropdown-content">
                 <template is="dom-repeat" items="[[toggleColumns]]" as="column" index-as="index">
                   <paper-icon-item position="[[column.position]]" on-tap="_hideColumn">
-                    <template is="dom-if" if="[[column.show]]">
+                    <template is="dom-if" if="[[column.hidden]]">
                       <iron-icon icon="visibility-off" item-icon></iron-icon>
                     </template>
-                    <template is="dom-if" if="[[!column.show]]">
+                    <template is="dom-if" if="[[!column.hidden]]">
                       <iron-icon disabled icon="visibility" item-icon></iron-icon>
                     </template>
                     [[column.header]]

--- a/demo/data/data-page=0&size=2&sort=.json
+++ b/demo/data/data-page=0&size=2&sort=.json
@@ -9,11 +9,19 @@
     "data": [
       {
         "color": "yellow",
-        "fruit": "banana"
+        "fruit": "banana",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "apple",
-        "color": "green"
+        "color": "green",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=0&size=2&sort=fruit,asc.json
+++ b/demo/data/data-page=0&size=2&sort=fruit,asc.json
@@ -9,11 +9,19 @@
     "data": [
       {
         "fruit": "apple",
-        "color": "green"
+        "color": "green",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "color": "yellow",
-        "fruit": "banana"
+        "fruit": "banana",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=0&size=2&sort=fruit,desc.json
+++ b/demo/data/data-page=0&size=2&sort=fruit,desc.json
@@ -9,11 +9,19 @@
     "data": [
       {
         "color": "yellow",
-        "fruit": "banana"
+        "fruit": "banana",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "apple",
-        "color": "green"
+        "color": "green",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=0&size=4&sort=.json
+++ b/demo/data/data-page=0&size=4&sort=.json
@@ -9,19 +9,35 @@
     "data": [
       {
         "color": "yellow",
-        "fruit": "banana"
+        "fruit": "banana",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "apple",
-        "color": "green"
+        "color": "green",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "color": "orange",
-        "fruit": "orange"
+        "fruit": "orange",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "strawberry",
-        "color": "pink"
+        "color": "pink",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=0&size=4&sort=fruit,asc.json
+++ b/demo/data/data-page=0&size=4&sort=fruit,asc.json
@@ -9,19 +9,35 @@
     "data": [
       {
         "color": "yellow",
-        "fruit": "banana"
+        "fruit": "banana",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "apple",
-        "color": "green"
+        "color": "green",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "color": "orange",
-        "fruit": "orange"
+        "fruit": "orange",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "strawberry",
-        "color": "pink"
+        "color": "pink",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=0&size=4&sort=fruit,desc.json
+++ b/demo/data/data-page=0&size=4&sort=fruit,desc.json
@@ -9,19 +9,35 @@
     "data": [
       {
         "fruit": "strawberry",
-        "color": "pink"
+        "color": "pink",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "color": "orange",
-        "fruit": "orange"
+        "fruit": "orange",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "apple",
-        "color": "green"
+        "color": "green",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "color": "yellow",
-        "fruit": "banana"
+        "fruit": "banana",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=1&size=2&sort=.json
+++ b/demo/data/data-page=1&size=2&sort=.json
@@ -9,11 +9,19 @@
     "data": [
       {
         "color": "orange",
-        "fruit": "orange"
+        "fruit": "orange",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "strawberry",
-        "color": "pink"
+        "color": "pink",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=1&size=2&sort=fruit,asc.json
+++ b/demo/data/data-page=1&size=2&sort=fruit,asc.json
@@ -9,11 +9,19 @@
     "data": [
       {
         "color": "orange",
-        "fruit": "orange"
+        "fruit": "orange",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "strawberry",
-        "color": "pink"
+        "color": "pink",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=1&size=2&sort=fruit,desc.json
+++ b/demo/data/data-page=1&size=2&sort=fruit,desc.json
@@ -9,11 +9,19 @@
     "data": [
       {
         "fruit": "strawberry",
-        "color": "pink"
+        "color": "pink",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "color": "orange",
-        "fruit": "orange"
+        "fruit": "orange",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/data/data-page=1&size=2.json
+++ b/demo/data/data-page=1&size=2.json
@@ -9,11 +9,19 @@
     "data": [
       {
         "color": "orange",
-        "fruit": "orange"
+        "fruit": "orange",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       },
       {
         "fruit": "strawberry",
-        "color": "pink"
+        "color": "pink",
+        "weight": {
+          "kg": "0.12gr",
+          "gr": "120gr"
+        }
       }
     ]
   }

--- a/demo/fakeapi-sample.html
+++ b/demo/fakeapi-sample.html
@@ -49,13 +49,12 @@
       },
       _handleResponse: function(event) {
         this._response = event.detail.response;
-        console.log(this._response);
 
         /*
          * Keep only first element (this.size)
          */
         this.data = this._response.slice(0, this.size);
-        this.totalElements = 6; 
+        this.totalElements = 6;
         this.totalPages = 3;
       },
       _handleSizeChanged: function(size) {

--- a/dist/paper-datatable-api-column.js
+++ b/dist/paper-datatable-api-column.js
@@ -39,11 +39,11 @@ var DtPaperDatatableApiColumn = function () {
           value: false
         },
         /**
-         * If false, the column is hidden.
+         * If true, the column is hidden.
          */
-        show: {
+        hidden: {
           type: Boolean,
-          value: true
+          value: false
         },
         /**
          * Current sort direction (asc or desc).
@@ -71,7 +71,7 @@ var DtPaperDatatableApiColumn = function () {
           value: false
         },
         /**
-         * If true, the column can be hide.
+         * If true, the column can be hidden.
          */
         hideable: {
           type: Boolean,

--- a/dist/paper-datatable-api.html
+++ b/dist/paper-datatable-api.html
@@ -15,6 +15,8 @@
 
 `paper-datatable-api` is a material design implementation of a data table.
 
+    <link rel="import" href="bower_components/paper-datatable-api/dist/paper-datatable-api-column.html">
+    <link rel="import" href="bower_components/paper-datatable-api/dist/paper-datatable-api.html">
     <iron-ajax auto url="data.json" last-response="{{data}}"></iron-ajax>
 
     <paper-datatable-api data="[[data]]">
@@ -34,7 +36,7 @@
 
 - [Follows the guideline of Material Design](https://material.google.com/components/data-tables.html#)
 - Hide/Show columns
-- Choose which columns can be hidden or show
+- Choose which columns can be hidden or shown
 - Sort
 - Pagination
 - Checkboxes to select or manipulate data
@@ -82,7 +84,13 @@ Custom property                                   | Description                 
               </th>
             </template>
             <template is="dom-repeat" items="[[_columns]]" as="column">
-              <th class$="[[_generateClass(filters)]] pgTh" data-column="[[column]]" sort-direction$="[[column.sortDirection]]" sorted$="[[column.sorted]]" sortable$="[[column.sortable]]">
+              <th
+                class$="[[_generateClass(filters)]] pgTh"
+                data-column="[[column]]"
+                sort-direction$="[[column.sortDirection]]"
+                sorted$="[[column.sorted]]"
+                sortable$="[[column.sortable]]"
+                style="display: [[_getThDisplayStyle(column.hidden)]];">
 
                 <div class="layout horizontal center">
 

--- a/dist/paper-datatable-api.js
+++ b/dist/paper-datatable-api.js
@@ -229,7 +229,7 @@ var DtPaperDatatableApi = function () {
 
       var pgTrs = Polymer.dom(this.root).querySelectorAll('.paper-datatable-api-tr');
       pgTrs.forEach(function (pgTr) {
-        Polymer.dom(_this.$$('tbody')).removeChild(pgTr);
+        return Polymer.dom(_this.$$('tbody')).removeChild(pgTr);
       });
     }
   }, {
@@ -275,12 +275,6 @@ var DtPaperDatatableApi = function () {
         _this3._columns.forEach(function (paperDatatableApiColumn) {
           var valueFromRowData = _this3._extractData(rowData, paperDatatableApiColumn.property);
 
-          var isHidden = false;
-
-          if (_this3.toggleColumns[paperDatatableApiColumn.position] && !_this3.toggleColumns[paperDatatableApiColumn.position].show) {
-            isHidden = true;
-          }
-
           var otherPropertiesValue = {};
           paperDatatableApiColumn.otherProperties.forEach(function (property) {
             otherPropertiesValue[property] = _this3._extractData(rowData, property);
@@ -289,7 +283,7 @@ var DtPaperDatatableApi = function () {
           var tdLocal = document.createElement('td');
           var template = paperDatatableApiColumn.fillTemplate(valueFromRowData, otherPropertiesValue);
 
-          if (isHidden) {
+          if (paperDatatableApiColumn.hideable && paperDatatableApiColumn.hidden) {
             tdLocal.style.display = 'none';
           }
 
@@ -407,23 +401,31 @@ var DtPaperDatatableApi = function () {
       var column = this._columns[columnPosition];
       if (column && column.hideable) {
         (function () {
-          var isShow = column.show;
+          var isHidden = column.hidden;
           var indexColumn = _this5.selectable ? columnPosition + 2 : columnPosition + 1;
           var cssQuery = 'tr th:nth-of-type(' + indexColumn + '), tr td:nth-of-type(' + indexColumn + ')';
           Polymer.dom(_this5.root).querySelectorAll(cssQuery).forEach(function (tdThParams) {
             var tdTh = tdThParams;
-            var displayMode = isShow ? 'none' : 'table-cell';
-            tdTh.style.display = displayMode;
+            tdTh.style.display = isHidden ? 'table-cell' : 'none';
           });
 
-          column.show = !isShow;
+          column.hidden = !isHidden;
           var toggleColumnIndex = _this5.toggleColumns.findIndex(function (toggleColumn) {
             return toggleColumn.position === columnPosition;
           });
 
-          _this5.set('toggleColumns.' + toggleColumnIndex + '.show', !isShow);
+          _this5.set('toggleColumns.' + toggleColumnIndex + '.hidden', !isHidden);
         })();
       }
+    }
+  }, {
+    key: '_getThDisplayStyle',
+    value: function _getThDisplayStyle(hidden) {
+      if (hidden) {
+        return 'none';
+      }
+
+      return 'table-cell';
     }
   }, {
     key: '_newSizeIsSelected',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,3 +11,6 @@ gulp.task('build', () => {
   gulp.src('src/*.html')
   .pipe(gulp.dest('./dist'));
 });
+
+// Default Task
+gulp.task('default', ['build']);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "devDependencies": {
     "babel-preset-es2015": "6.1.18",
-    "gulp": "3.9.1",
+    "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2"
   },
   "dependencies": {
+    "babel-preset-es2015": "^6.14.0",
     "gulp-babel": "^6.1.2"
   }
 }

--- a/paper-datatable-api-column.html
+++ b/paper-datatable-api-column.html
@@ -53,11 +53,11 @@
           value: false,
         },
         /**
-         * If false, the column is hidden.
+         * If true, the column is hidden.
          */
-        show: {
+        hidden: {
           type: Boolean,
-          value: true,
+          value: false,
         },
         /**
          * Current sort direction (asc or desc).
@@ -85,7 +85,7 @@
           value: false,
         },
         /**
-         * If true, the column can be hide.
+         * If true, the column will be hidden.
          */
         hideable: {
           type: Boolean,
@@ -104,7 +104,7 @@
       behaviors: [
         Polymer.Templatizer
       ],
-      
+
       ready: function() {
         var props = {};
         props.__key__ = true;
@@ -124,7 +124,7 @@
        */
       fillTemplate: function(value, otherValues) {
         var instance = this.stamp({ value: value, otherValues: otherValues });
-        return instance; 
+        return instance;
       },
     });
   </script>

--- a/paper-datatable-api.html
+++ b/paper-datatable-api.html
@@ -34,7 +34,7 @@
 
 - [Follows the guideline of Material Design](https://material.google.com/components/data-tables.html#)
 - Hide/Show columns
-- Choose which columns can be hidden or show
+- Choose which columns can be hidden or shown
 - Sort
 - Pagination
 - Checkboxes to select or manipulate data
@@ -82,7 +82,13 @@ Custom property                                   | Description                 
               </th>
             </template>
             <template is="dom-repeat" items="[[_columns]]" as="column">
-              <th class$="[[_generateClass(filters)]] pgTh" data-column="[[column]]" sort-direction$="[[column.sortDirection]]" sorted$="[[column.sorted]]" sortable$="[[column.sortable]]">
+              <th
+                class$="[[_generateClass(filters)]] pgTh"
+                data-column="[[column]]"
+                sort-direction$="[[column.sortDirection]]"
+                sorted$="[[column.sorted]]"
+                sortable$="[[column.sortable]]"
+                style="display: [[_getThDisplayStyle(column.hidden)]];">
 
                 <div class="layout horizontal center">
 
@@ -450,13 +456,6 @@ Custom property                                   | Description                 
 
             var valueFromRowData = this._extractData(rowData, paperDatatableApiColumn.property);
 
-            var isHidden = false;
-
-            if (this.toggleColumns[paperDatatableApiColumn.position] &&
-              !this.toggleColumns[paperDatatableApiColumn.position].show) {
-              isHidden = true;
-            }
-
             var otherPropertiesValue = {};
             paperDatatableApiColumn.otherProperties.forEach(function (property) {
               otherPropertiesValue[property] = this._extractData(rowData, property);
@@ -468,7 +467,7 @@ Custom property                                   | Description                 
               otherPropertiesValue
             );
 
-            if (isHidden) {
+            if (paperDatatableApiColumn.hideable && paperDatatableApiColumn.hidden) {
               tdLocal.style.display = 'none';
             }
 
@@ -577,22 +576,25 @@ Custom property                                   | Description                 
       toggleColumn: function (columnPosition) {
         var column = this._columns[columnPosition];
         if (column && column.hideable) {
-          var isShow = column.show;
+          var isHidden = column.hidden;
           var indexColumn = this.selectable ? columnPosition + 2 : columnPosition + 1;
           var cssQuery = 'tr th:nth-of-type(' + indexColumn +
           '), tr td:nth-of-type(' + indexColumn + ')';
           Polymer.dom(this.root).querySelectorAll(cssQuery).forEach(function (tdTh) {
-            var displayMode = isShow ? 'none' : 'table-cell';
-            tdTh.style.display = displayMode;
+            tdTh.style.display = isHidden ? 'table-cell' : 'none';
           }, this);
 
-          column.show = !isShow;
+          column.hidden = !isHidden;
           var toggleColumnIndex = this.toggleColumns.findIndex(function (toggleColumn) {
             return toggleColumn.position === columnPosition;
           });
 
-          this.set('toggleColumns.' + toggleColumnIndex + '.show', isShow ? false : true);
+          this.set('toggleColumns.' + toggleColumnIndex + '.hidden', !isHidden);
         }
+      },
+
+      _getThDisplayStyle: function (hidden) {
+        return hidden ? 'none' : 'table-cell';
       },
 
       _newSizeIsSelected: function () {

--- a/src/paper-datatable-api-column.js
+++ b/src/paper-datatable-api-column.js
@@ -28,11 +28,11 @@ class DtPaperDatatableApiColumn {
         value: false,
       },
       /**
-       * If false, the column is hidden.
+       * If true, the column is hidden.
        */
-      show: {
+      hidden: {
         type: Boolean,
-        value: true,
+        value: false
       },
       /**
        * Current sort direction (asc or desc).
@@ -60,7 +60,7 @@ class DtPaperDatatableApiColumn {
         value: false,
       },
       /**
-       * If true, the column can be hide.
+       * If true, the column can be hidden.
        */
       hideable: {
         type: Boolean,

--- a/src/paper-datatable-api.html
+++ b/src/paper-datatable-api.html
@@ -36,7 +36,7 @@
 
 - [Follows the guideline of Material Design](https://material.google.com/components/data-tables.html#)
 - Hide/Show columns
-- Choose which columns can be hidden or show
+- Choose which columns can be hidden or shown
 - Sort
 - Pagination
 - Checkboxes to select or manipulate data
@@ -84,7 +84,13 @@ Custom property                                   | Description                 
               </th>
             </template>
             <template is="dom-repeat" items="[[_columns]]" as="column">
-              <th class$="[[_generateClass(filters)]] pgTh" data-column="[[column]]" sort-direction$="[[column.sortDirection]]" sorted$="[[column.sorted]]" sortable$="[[column.sortable]]">
+              <th
+                class$="[[_generateClass(filters)]] pgTh"
+                data-column="[[column]]"
+                sort-direction$="[[column.sortDirection]]"
+                sorted$="[[column.sorted]]"
+                sortable$="[[column.sortable]]"
+                style="display: [[_getThDisplayStyle(column.hidden)]];">
 
                 <div class="layout horizontal center">
 

--- a/src/paper-datatable-api.js
+++ b/src/paper-datatable-api.js
@@ -251,13 +251,6 @@ class DtPaperDatatableApi {
       this._columns.forEach((paperDatatableApiColumn) => {
         const valueFromRowData = this._extractData(rowData, paperDatatableApiColumn.property);
 
-        let isHidden = false;
-
-        if (this.toggleColumns[paperDatatableApiColumn.position] &&
-          !this.toggleColumns[paperDatatableApiColumn.position].show) {
-          isHidden = true;
-        }
-
         const otherPropertiesValue = {};
         paperDatatableApiColumn.otherProperties.forEach((property) => {
           otherPropertiesValue[property] = this._extractData(rowData, property);
@@ -269,7 +262,7 @@ class DtPaperDatatableApi {
           otherPropertiesValue
         );
 
-        if (isHidden) {
+        if (paperDatatableApiColumn.hideable && paperDatatableApiColumn.hidden) {
           tdLocal.style.display = 'none';
         }
 
@@ -375,22 +368,29 @@ class DtPaperDatatableApi {
   toggleColumn(columnPosition) {
     const column = this._columns[columnPosition];
     if (column && column.hideable) {
-      const isShow = column.show;
+      const isHidden = column.hidden;
       const indexColumn = this.selectable ? columnPosition + 2 : columnPosition + 1;
       const cssQuery = `tr th:nth-of-type(${indexColumn}), tr td:nth-of-type(${indexColumn})`;
       Polymer.dom(this.root).querySelectorAll(cssQuery).forEach((tdThParams) => {
         const tdTh = tdThParams;
-        const displayMode = isShow ? 'none' : 'table-cell';
-        tdTh.style.display = displayMode;
+        tdTh.style.display = isHidden ? 'table-cell' : 'none';
       });
 
-      column.show = !isShow;
+      column.hidden = !isHidden;
       const toggleColumnIndex = this.toggleColumns.findIndex(
         toggleColumn => toggleColumn.position === columnPosition
       );
 
-      this.set(`toggleColumns.${toggleColumnIndex}.show`, !isShow);
+      this.set(`toggleColumns.${toggleColumnIndex}.hidden`, !isHidden);
     }
+  }
+
+  _getThDisplayStyle(hidden) {
+    if (hidden) {
+      return 'none';
+    }
+
+    return 'table-cell';
   }
 
   _newSizeIsSelected() {


### PR DESCRIPTION
Fixes #10

The attribute named show was replaced by hidden to make it possible
to hide a column by default.

An example was added to the advanced demo.

Some of the changes in "dist/paper-datatable-api.js" were not part of my code.
Maybe gulp wasn't executed?
