### PR TITLE
Add resources for the ‘en-us’ locale

### DIFF
--- a/dist/paper-datatable-api.js
+++ b/dist/paper-datatable-api.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -144,15 +144,19 @@ var DtPaperDatatableApi = function () {
           value: function value() {
             return {
               en: {
-                rowPerPage: 'Row per page',
+                rowPerPage: 'Rows per page',
                 of: 'of'
               },
               'en-en': {
-                rowPerPage: 'Row per page',
+                rowPerPage: 'Rows per page',
                 of: 'of'
               },
               'en-US': {
-                rowPerPage: 'Row per page',
+                rowPerPage: 'Rows per page',
+                of: 'of'
+              },
+              'en-us': {
+                rowPerPage: 'Rows per page',
                 of: 'of'
               },
               fr: {

--- a/src/paper-datatable-api.js
+++ b/src/paper-datatable-api.js
@@ -127,15 +127,19 @@ class DtPaperDatatableApi {
         value() {
           return {
             en: {
-              rowPerPage: 'Row per page',
+              rowPerPage: 'Rows per page',
               of: 'of',
             },
             'en-en': {
-              rowPerPage: 'Row per page',
+              rowPerPage: 'Rows per page',
               of: 'of',
             },
             'en-US': {
-              rowPerPage: 'Row per page',
+              rowPerPage: 'Rows per page',
+              of: 'of',
+            },
+            'en-us': {
+              rowPerPage: 'Rows per page',
               of: 'of',
             },
             fr: {


### PR DESCRIPTION
Safari (at least 10.0) returns "en-us" instead of "en-US" as its `navigator.language`. This doesn't seem to play well with the app-localize-behavior and/or other packages in its stack. Also, a small grammar change. The build somehow also updated that seemingly unrelated line in dist/, I can remove it if it's a big deal.

Thanks, and great work!