### PR TITLE
Fix package.json for use with Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,22 @@
 {
+	"name": "paper-datatable-api",
+	"description": "A material design implementation of a data table",
+	"version": "2.0.8",
+	"keywords": [
+		"web-component",
+		"web-components",
+		"polymer",
+		"datatable",
+		"grid",
+		"table"
+	],
+	"maintainers": [
+		{
+		  "name": "Julien Rousseau - RoXuS",
+		  "email": "",
+		  "web": ""
+		}
+	],
 	"devDependencies": {
 		"babel-preset-es2015": "6.1.18",
 		"gulp": "^3.9.1",


### PR DESCRIPTION
The current package.json creates errors when using Yarn to manage packages by having no version number.

![image](https://user-images.githubusercontent.com/7241159/31496093-4eef480e-af5a-11e7-8be4-d58c652781a3.png)

Otherwise everything is ready for [the migration away from Bower](https://bower.io/blog/2017/how-to-migrate-away-from-bower/)

