### PR TITLE
Import legacy Polymer methods where needed

### DIFF
--- a/paper-datatable-api-column.html
+++ b/paper-datatable-api-column.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/polymer.html">
 
 <!--
 


### PR DESCRIPTION
`Polymer.mixinBehavior` is not part of `polymer-element.html` but `polymer.html` and thus it doesn't work if you don't import `polymer.html` anywhere else in the app. However, you cannot ensure that and should include all needed imports inside the element.

I came across this building an app and verified that after this change everything works as it should.